### PR TITLE
Add ports configuration for multiple services in docker-compose.yml

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -158,6 +158,8 @@ services:
       - TEMP_DIR=${TEMP_DIR}
       - MAX_DOWNLOAD_SIZE=${MAX_DOWNLOAD_SIZE}
       - DOWNLOAD_TIMEOUT=${DOWNLOAD_TIMEOUT}
+    ports:
+      - "8001:8001"
     volumes:
       - storage_data:${STORAGE_PATH}
       - temp_data:${TEMP_DIR}
@@ -184,6 +186,8 @@ services:
       - VAD_FILTER=${VAD_FILTER}
       - VAD_THRESHOLD=${VAD_THRESHOLD}
       - TEMP_DIR=${TEMP_DIR}
+    ports:
+      - "8002:8002"
     volumes:
       - storage_data:${STORAGE_PATH}
       - temp_data:${TEMP_DIR}
@@ -216,6 +220,9 @@ services:
       - FACE_CONFIDENCE_THRESHOLD=${FACE_CONFIDENCE_THRESHOLD}
       - FRAME_SAMPLE_RATE=${FRAME_SAMPLE_RATE}
       - TEMP_DIR=${TEMP_DIR}
+      - VISION_SERVICE_PORT=8003
+    ports:
+      - "8003:8003"
     volumes:
       - storage_data:${STORAGE_PATH}
       - temp_data:${TEMP_DIR}
@@ -251,6 +258,9 @@ services:
       - TOP_CLIPS_COUNT=${TOP_CLIPS_COUNT}
       - OVERLAP_THRESHOLD=${OVERLAP_THRESHOLD}
       - TEMP_DIR=${TEMP_DIR}
+      - PORT=8004
+    ports:
+      - "8004:8004"
     volumes:
       - storage_data:${STORAGE_PATH}
       - temp_data:${TEMP_DIR}
@@ -280,6 +290,9 @@ services:
       - WATERMARK_POSITION=${WATERMARK_POSITION}
       - WATERMARK_OPACITY=${WATERMARK_OPACITY}
       - TEMP_DIR=${TEMP_DIR}
+      - RENDER_SERVICE_PORT=8005
+    ports:
+      - "8005:8005"
     volumes:
       - storage_data:${STORAGE_PATH}
       - temp_data:${TEMP_DIR}


### PR DESCRIPTION
- Exposed ports 8001 to 8005 for ASR, Ingest, Vision, Render, and additional services.
- Updated environment variables to include service-specific port configurations.
- Ensured proper volume mappings remain intact for data storage.